### PR TITLE
[tavern] enable artifacthub security scan update

### DIFF
--- a/charts/tavern/Chart.yaml
+++ b/charts/tavern/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tavern
 description: "Unofficial Tavern Helm Chart"
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.0.4
 home: "https://tavern.readthedocs.io/en/latest/"
 icon: "https://tavern.readthedocs.io/en/latest/_static/icon.png"
@@ -21,8 +21,8 @@ maintainers:
   - name: chifu1234
     email: kk@sudo-i.net
 annotations:
-  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/prerelease: "true"
   artifacthub.io/images: |
     - name: tavern
-      image: buttahtoast/docker-tavern:1.0.3
+      image: buttahtoast/docker-tavern:1.0.4


### PR DESCRIPTION
Signed-off-by: Kevin Klopfenstein <kk@sudo-i.net>

<!--
Thank you for  your contribution =) <3.
-->

**What this PR does**:
- enable securitscanupdate for artifacthub
- bump docker image for artifacthub

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Notes for Reviewer**:


**Checklist**:

- [x] Added documentation in `README.md`
- [x] Chart Version bumped
- [x] All commits are signed-off
